### PR TITLE
fix config.supports to match listentities object

### DIFF
--- a/lib/entities/Climate.js
+++ b/lib/entities/Climate.js
@@ -1,13 +1,13 @@
 const Base = require('./Base')
 
-// bool supports_current_temperature = 5;
-// bool supports_two_point_target_temperature = 6;
+// bool supportsCurrentTemperature = 5;
+// bool supportsTwoPointTargetTemperature = 6;
 // repeated ClimateMode supported_modes = 7;
 // float visual_min_temperature = 8;
 // float visual_max_temperature = 9;
 // float visual_temperature_step = 10;
-// bool supports_away = 11;
-// bool supports_action = 12;
+// bool supportsAway = 11;
+// bool supportsAction = 12;
 // repeated ClimateFanMode supported_fan_modes = 13;
 // repeated ClimateSwingMode supported_swing_modes = 14;
 class Climate extends Base {
@@ -37,11 +37,11 @@ class Climate extends Base {
         this.command({ targetTemperature });
     }
     setTargetTemperatureLow(targetTemperatureLow) {
-        if (!this.config.supports_two_point_target_temperature) throw new Error('two_point_target_temperature are not supported');
+        if (!this.config.supportsTwoPointTargetTemperature) throw new Error('two_point_target_temperature are not supported');
         this.command({ targetTemperatureLow });
     }
     setTargetTemperatureHign(targetTemperatureHign) {
-        if (!this.config.supports_two_point_target_temperature) throw new Error('two_point_target_temperature are not supported');
+        if (!this.config.supportsTwoPointTargetTemperature) throw new Error('two_point_target_temperature are not supported');
         this.command({ targetTemperatureHign });
     }
     setMode(mode) {
@@ -50,11 +50,11 @@ class Climate extends Base {
         this.command({ mode });
     }
     setAway(away) {
-        if (!this.config.supports_away) throw new Error('away is not supported');
+        if (!this.config.supportsAway) throw new Error('away is not supported');
         this.command({ away });
     }
     setAction(action) {
-        if (!this.config.supports_action) throw new Error('action is not supported');
+        if (!this.config.supportsAction) throw new Error('action is not supported');
         this.command({ action });
     }
     setMode(mode) {

--- a/lib/entities/Cover.js
+++ b/lib/entities/Cover.js
@@ -2,8 +2,8 @@ const Base = require('./Base')
 
 
 // bool assumed_state = 5;
-// bool supports_position = 6;
-// bool supports_tilt = 7;
+// bool supportsPosition = 6;
+// bool supportsTilt = 7;
 // string device_class = 8;
 class Cover extends Base {
     constructor(data) {
@@ -27,11 +27,11 @@ class Cover extends Base {
         this.command({ legacyCommand });
     }
     setPosition(position) {
-        if (!this.config.supports_position) throw new Error('brightness is not supported');
+        if (!this.config.supportsPosition) throw new Error('brightness is not supported');
         this.command({ position });
     }
     setTilt(tilt) {
-        if (!this.config.supports_tilt) throw new Error('tilt is not supported');
+        if (!this.config.supportsTilt) throw new Error('tilt is not supported');
         this.command({ tilt });
     }
     setStop(stop) {

--- a/lib/entities/Fan.js
+++ b/lib/entities/Fan.js
@@ -1,7 +1,7 @@
 const Base = require('./Base')
 
-// bool supports_oscillation = 5;
-// bool supports_speed = 6;
+// bool supportsOscillation = 5;
+// bool supportsSpeed = 6;
 class Fan extends Base {
     constructor(data) {
         super(data);
@@ -21,11 +21,11 @@ class Fan extends Base {
         this.command({ state });
     }
     setOscillation(oscillation) {
-        if (!this.config.supports_oscillation) throw new Error('brightness is not supported');
+        if (!this.config.supportsOscillation) throw new Error('brightness is not supported');
         this.command({ oscillation });
     }
     setSpeed(speed) {
-        if (!this.config.supports_speed) throw new Error('brightness is not supported');
+        if (!this.config.supportsSpeed) throw new Error('brightness is not supported');
         this.command({ speed });
     }
 }

--- a/lib/entities/Light.js
+++ b/lib/entities/Light.js
@@ -1,10 +1,10 @@
 const { LightCommandRequest } = require('../protoc/api_pb');
 const Base = require('./Base');
 
-// bool supports_brightness = 5;
-// bool supports_rgb = 6;
-// bool supports_white_value = 7; 
-// bool supports_color_temperature = 8;
+// bool supportsBrightness = 5;
+// bool supportsRgb = 6;
+// bool supportsWhiteValue = 7;
+// bool supportsColorTemperature = 8;
 // float min_mireds = 9;
 // float max_mireds = 10;
 // repeated string effects = 11;
@@ -25,10 +25,10 @@ class Light extends Base {
     // handleState(state) {
     //     super.handleState(state);
     //     this.emit('state.state', this.state.state);
-    //     if (this.config.supports_brightness) this.emit('state.brightness', this.state.brightness);
-    //     if (this.config.supports_rgb) this.emit('state.rgb', this.state.red, this.state.green, this.state.blue);
-    //     if (this.config.supports_white_value) this.emit('state.white', this.state.white);
-    //     if (this.config.supports_color_temperature) this.emit('state.colorTemperature', this.state.white);
+    //     if (this.config.supportsBrightness) this.emit('state.brightness', this.state.brightness);
+    //     if (this.config.supportsRgb) this.emit('state.rgb', this.state.red, this.state.green, this.state.blue);
+    //     if (this.config.supportsWhiteValue) this.emit('state.white', this.state.white);
+    //     if (this.config.supportsColorTemperature) this.emit('state.colorTemperature', this.state.white);
     // }
     //   fixed32 key = 1;
     //   bool has_state = 2;
@@ -57,19 +57,19 @@ class Light extends Base {
         this.command({ state });
     }
     setBrightness(brightness) {
-        if (!this.config.supports_brightness) throw new Error('brightness is not supported');
+        if (!this.config.supportsBrightness) throw new Error('brightness is not supported');
         this.command({ brightness });
     }
     setRgb(red, green, blue) {
-        if (!this.config.supports_rgb) throw new Error('rgb is not supported');
+        if (!this.config.supportsRgb) throw new Error('rgb is not supported');
         this.command({ red, green, blue });
     }
     setWhite(white) {
-        if (!this.config.supports_white_value) throw new Error('white_value is not supported');
+        if (!this.config.supportsWhiteValue) throw new Error('white_value is not supported');
         this.command({ white });
     }
     setColorTemperature(colorTemperature) {
-        if (!this.config.supports_color_temperature) throw new Error('white_value is not supported');
+        if (!this.config.supportsColorTemperature) throw new Error('white_value is not supported');
         this.command({ colorTemperature });
     }
     setTransitionLength(transitionLength) {


### PR DESCRIPTION
Not sure if you're accepting pull requests, but thanks for taking a look.

I found commands like `entity.setBrightness(0.9)` were throwing `brightness is not supported` errors due to a miss-match between the entity config and these setter methods. I've modified the name of each property in the `if` statements.

```
supportsBrightness: jspb.Message.getBooleanFieldWithDefault(msg, 5, false),
```

```
if (!this.config.supports_brightness) throw new Error('brightness is not supported');
```